### PR TITLE
fix: storybook args for header title

### DIFF
--- a/src/stories/Header.stories.tsx
+++ b/src/stories/Header.stories.tsx
@@ -6,27 +6,19 @@ export default {
   component: AnTitle,
   argTypes: {
     label: {
-      control: {
-        type: "text",
-      },
+      control: "text",
     },
     size: {
-      control: {
-        type: "select",
-        options: ["h1", "h2", "h3", "h4", "h5", "h6"],
-      },
+      control: "select",
+      options: ["h1", "h2", "h3", "h4", "h5", "h6"],
     },
     weight: {
-      control: {
-        type: "select",
-        options: ["light", "regular", "medium", "semibold", "bold"],
-      },
+      control: "select",
+      options: ["light", "regular", "medium", "semibold", "bold"],
     },
     align: {
-      control: {
-        type: "select",
-        options: ["left", "center", "right"],
-      },
+      control: "select",
+      options: ["left", "center", "right"],
     },
   },
 } as ComponentMeta<typeof AnTitle>;


### PR DESCRIPTION
This is a bug on storybook not warning you that the ArgTypes are invalid

[here](https://github.com/AnimaApp/anima-website-components/blob/master/src/stories/Header.stories.tsx) is the doc on it